### PR TITLE
Fixed Bracket in cu3 Matrix

### DIFF
--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -154,7 +154,7 @@ class CU3Gate(ControlledGate):
                     1 & 0   & 0                  & 0 \\
                     0 & 1   & 0                  & 0 \\
                     0 & 0   & \cos(\th)          & -e^{i\lambda}\sin(\th) \\
-                    0 & 0   & e^{i\phi}\sin(\th) & e^{i(\phi+\lambda)\cos(\th)}
+                    0 & 0   & e^{i\phi}\sin(\th) & e^{i(\phi+\lambda)}\cos(\th)
                 \end{pmatrix}
     """
 

--- a/qiskit/circuit/library/standard_gates/u3.py
+++ b/qiskit/circuit/library/standard_gates/u3.py
@@ -128,7 +128,7 @@ class CU3Gate(ControlledGate):
                 1 & 0                   & 0 & 0 \\
                 0 & \cos(\th)           & 0 & -e^{i\lambda}\sin(\th) \\
                 0 & 0                   & 1 & 0 \\
-                0 & e^{i\phi}\sin(\th)  & 0 & e^{i(\phi+\lambda)\cos(\th)}
+                0 & e^{i\phi}\sin(\th)  & 0 & e^{i(\phi+\lambda)}\cos(\th)
             \end{pmatrix}
 
     .. note::


### PR DESCRIPTION
The cos in the bottom right term was included in the argument of the exponential when it shouldn't be due to a misplaced '}'.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [y] I have added the tests to cover my changes.
- [y] I have updated the documentation accordingly.
- [y] I have read the CONTRIBUTING document.
-->

### Summary

Fixed a misplaced bracket in the matrix description of cu3

### Details and comments

The ending bracket in the lower right matrix element was misplaced, causing the cosine term to be included in the argument of the exponential when it shouldn't be.
